### PR TITLE
Escaping file names before feeding them to execCmd

### DIFF
--- a/src/nasher/unpack.nim
+++ b/src/nasher/unpack.nim
@@ -1,7 +1,7 @@
 import tables, os, strformat, strutils, times
 from glob import walkGlob
 
-import utils/[cli, compiler, nwn, options, shared]
+import utils/[cli, nwn, options, shared]
 
 const
   helpUnpack* = """

--- a/src/nasher/unpack.nim
+++ b/src/nasher/unpack.nim
@@ -1,7 +1,7 @@
 import tables, os, strformat, strutils, times
 from glob import walkGlob
 
-import utils/[cli, nwn, options, shared]
+import utils/[cli, compiler, nwn, options, shared]
 
 const
   helpUnpack* = """

--- a/src/nasher/utils/nwn.nim
+++ b/src/nasher/utils/nwn.nim
@@ -15,7 +15,7 @@ proc gffToJson(file, bin, args: string): JsonNode =
   ## Converts ``file`` to json, stripping the module ID if ``file`` is
   ## module.ifo.
   let
-    cmd = join([bin, args, "-i", file, "-k json -p"], " ")
+    cmd = join([bin, args, "-i", file.escape, "-k json -p"], " ")
     (output, errCode) = execCmdEx(cmd, Options)
 
   if errCode != 0:
@@ -31,7 +31,7 @@ proc gffToJson(file, bin, args: string): JsonNode =
 proc jsonToGff(inFile, outFile, bin, args: string) =
   ## Converts a json ``inFile`` to an erf ``outFile``.
   let
-    cmd = join([bin, args, "-i", inFile, "-o", outFile], " ")
+    cmd = join([bin, args, "-i", inFile.escape, "-o", outFile.escape], " ")
     (output, errCode) = execCmdEx(cmd, Options)
 
   if errCode != 0:
@@ -108,7 +108,7 @@ proc createErf*(dir, outFile, bin, args: string) =
   ## Creates an erf file at ``outFile`` from all files in ``dir``, passing
   ## ``args`` to the ``nwn_erf`` utiltity.
   let
-    cmd = join([bin, args, "-c -f", outFile, dir], " ")
+    cmd = join([bin, args, "-c -f", outFile.escape, dir], " ")
     (output, errCode) = execCmdEx(cmd, Options)
 
   if errCode != 0:


### PR DESCRIPTION
Really love this tool but was experiencing some issues using it with our PW's quite ancient module.

The issue I experienced was that when files with spaces in their names were joined into the command passed to `execCmdEx`, results of various cli's was a help message instead of the expected notation and there was still a successful status code which then resulted in errors further in nasher's execution. Escaping all the file names mitigates this issue.

Feel free to ignore the "Removing unused import" commit and revert. I was correcting a linter warning in my local editor on my fork's master before realizing I wanted to put up a PR. In the interest of commit history you can squash this PR should you choose to approve it.