### PR TITLE
use SQL Transaction to speed-up inserts/updates

### DIFF
--- a/src/nasher/unpack.nim
+++ b/src/nasher/unpack.nim
@@ -169,6 +169,7 @@ proc unpack*(opts: Options, pkg: PackageRef) =
   var warnings = 0
 
   display("Converting", fmt"new or updated files")
+  db.sqlBegin()
   for file in changedFiles:
     let
       ext = file.fileName.splitFile.ext.strip(chars = {'.'})
@@ -194,6 +195,8 @@ proc unpack*(opts: Options, pkg: PackageRef) =
     gffConvert(filePath, outFile, gffUtil, gffFlags)
     outFile.setLastModificationTime(packTime)
     db.sqlUpsert(file.fileName, file.fileSha1, packTime, file.sqlSha1)
+
+  db.sqlCommit()
 
   if warnings > 0:
     let words =

--- a/src/nasher/utils/sql.nim
+++ b/src/nasher/utils/sql.nim
@@ -14,6 +14,12 @@ proc getDB*(fileName: string): DbConn =
 proc sqlDelete*(db:DbConn, fileName: string) =
   db.exec(sql"DELETE FROM tmp WHERE filename = ?", filename)
 
+proc sqlBegin*(db:DBConn) =
+  db.exec(sql"BEGIN")
+
+proc sqlCommit*(db:DBConn) =
+  db.exec(sql"COMMIT")
+
 proc sqlUpsert*(db:DbConn, fileName: string, fileSha1: string, packTime: Time, sqlSha1: string) =
   #Can't use true sqlite 'upsert' due to nim library not wrapping it.
   if sqlsha1 == "":


### PR DESCRIPTION
Minor change, but grouping all the sql transactions for an unpack into a single Transaction is a massive speed boost (several hundred times faster)