### PR TITLE
Force "Bearing" on 180 degrees to positive

### DIFF
--- a/src/nasher/utils/nwn.nim
+++ b/src/nasher/utils/nwn.nim
@@ -12,20 +12,26 @@ const
     "jrl", "gff", "gui"
   ]
 
-proc truncateFloats(j: var JsonNode, precision: range[1..32] = 4) =
+proc truncateFloats(j: var JsonNode, precision: range[1..32] = 4, bearing: bool = false) =
   case j.kind
   of JObject:
-    for _, v in j.mpairs:
-      v.truncateFloats(precision)
+    for k, v in j.mpairs:
+      if(k == "Bearing"):
+        v.truncateFloats(precision, true)
+      else:
+        v.truncateFloats(precision, bearing)
   of JArray:
     for e in j.mitems:
-      e.truncateFloats(precision)
+      e.truncateFloats(precision, bearing)
   of JFloat:
     var f = j.getFloat.formatFloat(ffDecimal, precision)
     f.trimZeros
     if {'.', 'e'} notin f:
       f.add(".0")
-    j = newJFloat(f.parseFloat)
+    j = newJFloat(
+      if bearing and f == formatFloat(-PI, ffDecimal, precision):
+        f.parseFloat.abs
+      else: f.parseFloat)
   else:
     discard
 


### PR DESCRIPTION
Objects in the world have a node called Bearing, which corresponds to the orientation of the asset, recorded as radians
```json
"Bearing": {
  "type": "float",
  "value": 1.5708
}
```
(Example of 90 degrees)

If the object is at 180 degrees, bearing is at exactly PI radians *and* exactly -PI radians. Loss of precision in conversion from degrees to Float-radians means that which side of this conversion (positive or negative) the particular bearing falls is essentially random at each save of the object in-toolset.

Once Nasher truncates the float, this results in significant additional diffs as a result of bearings changing from `-3.1416` to `3.1416` or vice versa, being an actual angle change of  < 0.001 degrees

This pull is my attempt to resolve the issue by detecting a "Bearing" node, and then if the float-value is the same as a similarly-truncated float of PI, we store the absolute of the float-value instead.

Note: I've tested this extracted proc via playground with sample data from my own PW. I have not yet had a chance to test a fully-compiled nasher on a whole module.