### PR TITLE
Add empty folders to dockerfile for install

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -15,6 +15,6 @@ RUN dpkg --add-architecture i386 \
 RUN nasher config --userName:"nasher"
 ENV PATH="/root/.nimble/bin:${PATH}"
 WORKDIR /nasher
-RUN mkdir -p /nasher/install/{modules,erf,hak,tlk}
+RUN bash -c 'mkdir -pv /nasher/install/{modules,erf,hak,tlk}'
 ENTRYPOINT [ "nasher" ]
 CMD [ "list --quiet" ]

--- a/dockerfile
+++ b/dockerfile
@@ -10,9 +10,14 @@ RUN dpkg --add-architecture i386 \
     && apt-get install libc6:i386 libncurses5:i386 libstdc++6:i386 -y \
     && choosenim update stable \
     && nimble install nasher@#0.11.8 -y \
-    && nasher config --nssFlags:"-n /nwn/data -o"
+    && nasher config --nssFlags:"-n /nwn/data -o" \
+    && nasher config --installDir:"/nasher/install"
 RUN nasher config --userName:"nasher"
 ENV PATH="/root/.nimble/bin:${PATH}"
 WORKDIR /nasher
+RUN mkdir -p /nasher/install/modules
+RUN mkdir -p /nasher/install/erf
+RUN mkdir -p /nasher/install/hak
+RUN mkdir -p /nasher/install/tlk
 ENTRYPOINT [ "nasher" ]
 CMD [ "list --quiet" ]

--- a/dockerfile
+++ b/dockerfile
@@ -15,9 +15,6 @@ RUN dpkg --add-architecture i386 \
 RUN nasher config --userName:"nasher"
 ENV PATH="/root/.nimble/bin:${PATH}"
 WORKDIR /nasher
-RUN mkdir -p /nasher/install/modules
-RUN mkdir -p /nasher/install/erf
-RUN mkdir -p /nasher/install/hak
-RUN mkdir -p /nasher/install/tlk
+RUN mkdir -p /nasher/install/{modules,erf,hak,tlk}
 ENTRYPOINT [ "nasher" ]
 CMD [ "list --quiet" ]


### PR DESCRIPTION
In answer to issue #39 this dockerfile should allow the install command to work correctly.  It adds empty directories to the dockerfile so default write locations for .mod/erf/hak/tlk can successful write into the container.  A successful docker run command will look something like this (windows):
```
docker run --rm -it -v ${pwd}:/nasher -v //c/Users/<user>/Documents/Neverwinter Nights:/nasher/install squattingmonk/nasher:latest install <target> <options>
```
The run command will set the NWNEE NWN document folder as a volume for the new internal /nasher/install folder.  Both directories contain folders for modules, erfs, haks and talks.  Above command successfully built a module file into the `/Documents/Neverwinter Nights/Modules` folder.

No such "dummy" folders are necessary for the pack command because the pack command appears to properly create the necessary folders within the container at runtime, while the install command does not.