### PR TITLE
initial git branch integration

### DIFF
--- a/nasher.nimble
+++ b/nasher.nimble
@@ -10,6 +10,6 @@ bin           = @["nasher"]
 
 # Dependencies
 
-requires "nim >= 1.2.0"
+requires "nim >= 1.4.0"
 requires "neverwinter >= 1.3.1"
 requires "glob >= 0.9.0"

--- a/src/nasher.nim
+++ b/src/nasher.nim
@@ -95,7 +95,8 @@ when isMainModule:
         opts["target"] = target.name
         if branch == "none":
           branch = target.branch
-        gitSetBranch(dir, branch)
+        if branch.len > 0:
+          display("VCS Branch:", gitSetBranch(dir, branch))
 
         if convert(opts, pkg) and
            compile(opts, pkg) and

--- a/src/nasher.nim
+++ b/src/nasher.nim
@@ -1,5 +1,6 @@
+import os, strformat
 import nasher/[init, list, config, unpack, convert, compile, pack, install, launch]
-import nasher/utils/[cli, options, shared]
+import nasher/utils/[cli, git, options, shared]
 
 const
   NimblePkgVersion {.strdefine.} = "devel"
@@ -46,11 +47,13 @@ when isMainModule:
     var
       opts = getOptions()
       pkg = new(PackageRef)
+      branch = opts.get("branch", "none")
 
     let
       cmd = opts.get("command")
       help = opts.get("help", false)
       version = opts.get("version", false)
+      dir = opts.getOrPut("directory", getCurrentDir())
 
     if version:
       echo "nasher " & NimblePkgVersion
@@ -90,6 +93,10 @@ when isMainModule:
       let targets = pkg.getTargets(opts.get("targets"))
       for target in targets:
         opts["target"] = target.name
+        if branch == "none":
+          branch = target.branch
+        gitSetBranch(dir, branch)
+
         if convert(opts, pkg) and
            compile(opts, pkg) and
            pack(opts, pkg) and

--- a/src/nasher/init.nim
+++ b/src/nasher/init.nim
@@ -37,6 +37,16 @@ proc init*(opts: Options, pkg: PackageRef): bool =
 
   display("Initializing", "into " & dir)
 
+  # TODO: support hg
+  if opts.getOrPut("vcs", "git") == "git":
+    try:
+      display("Initializing", "git repository")
+      if gitInit(dir):
+        gitIgnore(dir)
+        success("initialized git repository")
+    except:
+      error("Could not initialize git repository: " & getCurrentExceptionMsg())
+
   try:
     display("Creating", "package file at " & file)
     createDir(dir)
@@ -44,16 +54,6 @@ proc init*(opts: Options, pkg: PackageRef): bool =
     success("created package file")
   except:
     fatal("Could not create package file at " & file)
-
-  # TODO: support hg
-  if opts.getOrPut("vcs", "git") == "git":
-    try:
-      display("Initializing", "git repository")
-      if gitInit(dir):
-        gitIgnore(dir)
-      success("initialized git repository")
-    except:
-      error("Could not initialize git repository: " & getCurrentExceptionMsg())
 
   success("project initialized")
 

--- a/src/nasher/init.nim
+++ b/src/nasher/init.nim
@@ -37,6 +37,14 @@ proc init*(opts: Options, pkg: PackageRef): bool =
 
   display("Initializing", "into " & dir)
 
+  try:
+    display("Creating", "package file at " & file)
+    createDir(dir)
+    writeFile(file, genPackageText(opts))
+    success("created package file")
+  except:
+    fatal("Could not create package file at " & file)
+
   # TODO: support hg
   if opts.getOrPut("vcs", "git") == "git":
     try:
@@ -46,14 +54,6 @@ proc init*(opts: Options, pkg: PackageRef): bool =
         success("initialized git repository")
     except:
       error("Could not initialize git repository: " & getCurrentExceptionMsg())
-
-  try:
-    display("Creating", "package file at " & file)
-    createDir(dir)
-    writeFile(file, genPackageText(opts))
-    success("created package file")
-  except:
-    fatal("Could not create package file at " & file)
 
   success("project initialized")
 

--- a/src/nasher/list.nim
+++ b/src/nasher/list.nim
@@ -34,6 +34,7 @@ proc list*(opts: Options, pkg: PackageRef) =
       display("Includes:", target.includes.join("\n"))
       display("Excludes:", target.excludes.join("\n"))
       display("Filters:", target.filters.join("\n"))
+      display("Branch:", target.branch)
 
       for pattern, dir in target.rules.items:
         display("Rule:", pattern & " -> " & dir)

--- a/src/nasher/unpack.nim
+++ b/src/nasher/unpack.nim
@@ -1,7 +1,7 @@
 import tables, os, strformat, strutils, times
 from glob import walkGlob
 
-import utils/[cli, manifest, nwn, options, shared]
+import utils/[cli, git, manifest, nwn, options, shared]
 
 const
   helpUnpack* = """
@@ -117,12 +117,19 @@ proc unpack*(opts: Options, pkg: PackageRef) =
         of "hak": installDir / "hak" / fileName
         of "tlk": installDir / "tlk" / fileName
         else: dir / target.file
+    branch =
+      if opts.hasKey("branch"): opts.get("branch")
+      else: target.branch
 
   if file == "":
     help(helpUnpack)
 
   if not existsDir(file) and not existsFile(file):
     fatal(fmt"Cannot unpack {file}: file does not exist")
+
+  # Add git branch functionality here.  check for branch in options, if none, check in target
+  # gitSetBranch handles repo and branch existence checks
+  gitSetBranch(dir, branch)
 
   let
     fileType = file.getFileExt

--- a/src/nasher/utils/git.nim
+++ b/src/nasher/utils/git.nim
@@ -1,4 +1,4 @@
-import os, osproc, streams, strformat, strutils, uri
+import os, osproc, strformat, strutils, uri
 import cli
 
 from shared import withDir
@@ -41,19 +41,14 @@ proc gitRemote*(dir = getCurrentDir()): string =
 
 proc gitInit*(dir = getCurrentDir()): bool =
   ## Initializes dir as a git repository and returns whether the operation was
-  ## successful. Will throw an OSError if dir does not exist.
-  ## README.md created to prevent branch checkout errors before first commit
+  ## successful. Will throw an OSError if dir does not exist.  Init empty commit
+  ## made on branch `master` to force branch recognition
   var exitCode: int
 
   withDir(dir):
     exitCode = execCmdEx("git init").exitCode
     if exitCode == 0:
-      var s = openFileStream("README.md", fmWrite)
-      s.writeLine("My NWN Repo.")
-      s.close
-
-      discard gitExecCmd("git add README.md")
-      discard gitExecCmd("git commit -m \"initial commit\"")
+      discard execCmdEx("git commit --allow-empty -m \"root commit\"")
 
   result = exitCode == 0
 
@@ -61,6 +56,7 @@ proc gitExistsBranch(dir: string, branch: string): bool =
   ## Determines if passed branch exists in passed repository
   withDir(dir):
     gitExecCmd("git show-ref --verify refs/heads/" & branch, "error") != "error"
+    #gitExecCmd("git branch --list " & branch, "error") != "error"
 
 proc gitBranch*(dir = getCurrentDir()): string =
   ## Return name of the current branch

--- a/src/nasher/utils/git.nim
+++ b/src/nasher/utils/git.nim
@@ -104,5 +104,5 @@ proc gitIgnore*(dir = getCurrentDir(), force = false) =
     # Ignore the nasher directory
     .nasher/
     """
-  if force or not existsFile(dir / file):
+  if force or not fileExists(dir / file):
     writeFile(dir / file, text.unindent(4))

--- a/src/nasher/utils/shared.nim
+++ b/src/nasher/utils/shared.nim
@@ -44,12 +44,12 @@ proc getTimeDiffHint*(file: string, diff: int): string =
 proc fileOlder*(file: string, time: Time): bool =
   ## Checks whether file is older than a time. Only checks seconds since copying
   ## modification times results in unequal nanoseconds.
-  if existsFile(file):
+  if fileExists(file):
     getTimeDiff(time, file.getLastModificationTime) > 0
   else: true
 
 proc fileNewer*(file: string, time: Time): bool =
-  if existsFile(file):
+  if fileExists(file):
     getTimeDiff(time, file.getLastModificationTime) < 0
   else: false
 


### PR DESCRIPTION
Ok, here's the first hack at it.  Disclaimer:  this is the first programming I've ever attempted in nim, so feel free to hack away at it.  All spears accepted.  `Git Branch:` will be announced when any function that uses the repo is run.  Example output:
```ini
PS C:\Users\Ed\Desktop\Git Repositories\_nashertest> nasher pack default
 Git Branch: master
     Packing target default
    Updating cache for target default
         ... \Users\Ed\Documents\Neverwinter Nights\
    Success: compiled 5 scripts
     Packing files for target default into demo.mod
    Success: packed demo.mod
PS C:\Users\Ed\Desktop\Git Repositories\_nashertest> nasher pack git
 Git Branch: test
     Packing target git
    Updating cache for target git
    Skipping compilation: nothing to compile
     Packing files for target git into git.mod
    Success: packed git.mod
```

The branch name can be specified in four places and will be prioritized as follows:
1. Command line `--branch:<branch name>`
2. Configuration file `nasher config --local --branch:<branch name>`
3. `branch` key in nasher.cfg target
4. `branch` key in nasher.cfg package

If no branch name is specified, `master`, or the current branch, will be used.

Changing the branch is accomplished in two locations:
1. `unpack.nim`, because it's called from multiple places in `nasher.nim`
2. `nasher.nim`, in the `target` for loop so `install all` is still supported with differing target branches specified

Notes:
* Swapped order of git repo initialization and package creation in `init.nim` because package creation used some procedures that required git initialization to be accomplished first
* Added an empty `README.md` and commit in `git.nim` to prevent `git checkout` errors caused by new repos that haven't had a commit yet (no branches, including `master` exist before the first commit in the repo).

Reference #27.